### PR TITLE
feat: add --registry option to support custom npm registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ setup-npm-trusted-publish <package-name>
 Options:
 - `--dry-run` - Create the package but don't publish
 - `--access <public|restricted>` - Access level for scoped packages (default: public)
+- `--registry <url>` - npm registry URL (default: `https://registry.npmjs.org`)
 
 Environment Variables:
 - `NPM_TOKEN` - npm authentication token for users who don't have npm login configured locally. If set, a temporary `.npmrc` is created in the package directory with `//registry.npmjs.org/:_authToken=${NPM_TOKEN}`. npm expands `${NPM_TOKEN}` at runtime, so the actual token is never written to disk. The `.npmrc` is cleaned up with the temporary directory after publishing.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -25,6 +25,10 @@ const { values, positionals } = parseArgs({
     access: {
       type: 'string',
       default: 'public'
+    },
+    registry: {
+      type: 'string',
+      default: 'https://registry.npmjs.org'
     }
   },
   allowPositionals: true
@@ -44,6 +48,7 @@ Options:
   -v, --version   Show version
   --dry-run       Create the package but don't publish
   --access        Access level for scoped packages (public/restricted) [default: public]
+  --registry      npm registry URL [default: https://registry.npmjs.org]
 
 Example:
   setup-npm-trusted-publish my-package
@@ -157,9 +162,10 @@ For more details about npm's trusted publishing feature, see:
   // If NPM_TOKEN is set, create .npmrc for authentication
   const npmToken = process.env.NPM_TOKEN;
   if (npmToken) {
+    const registryUrl = new URL(values.registry);
     await writeFile(
       join(packageDir, '.npmrc'),
-      '//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n'
+      `registry=${values.registry}\n//${registryUrl.host}/:_authToken=\${NPM_TOKEN}\n`
     );
     console.log(`🔑 Using NPM_TOKEN for authentication`);
   }
@@ -171,12 +177,12 @@ For more details about npm's trusted publishing feature, see:
     console.log(`📁 Package location: ${packageDir}`);
     console.log(`\nTo publish manually:`);
     console.log(`  cd ${packageDir}`);
-    console.log(`  npm publish${packageName.startsWith('@') ? ' --access ' + values.access : ''}`);
+    console.log(`  npm publish --registry ${values.registry}${packageName.startsWith('@') ? ' --access ' + values.access : ''}`);
   } else {
     // Publish the package
     console.log(`\n📤 Publishing package to npm...`);
     
-    const publishArgs = ['publish'];
+    const publishArgs = ['publish', '--registry', values.registry];
     if (packageName.startsWith('@')) {
       publishArgs.push('--access', values.access);
     }
@@ -203,7 +209,7 @@ For more details about npm's trusted publishing feature, see:
       console.log(`\n📁 Package files are still available at: ${packageDir}`);
       console.log(`You can try publishing manually:`);
       console.log(`  cd ${packageDir}`);
-      console.log(`  npm publish${packageName.startsWith('@') ? ' --access ' + values.access : ''}`);
+      console.log(`  npm publish --registry ${values.registry}${packageName.startsWith('@') ? ' --access ' + values.access : ''}`);
       process.exit(1);
     }
   }


### PR DESCRIPTION
## Summary

Add a `--registry` CLI option that allows users to publish packages to custom npm-compatible registries (e.g., GitHub Packages, Verdaccio, private registries) instead of the default `https://registry.npmjs.org`.

When `NPM_TOKEN` is set, the generated `.npmrc` now correctly includes both the `registry=` line and a host-specific `_authToken` entry derived from the registry URL.

## Changes

- Add `--registry <url>` option to CLI (default: `https://registry.npmjs.org`)
- Update `.npmrc` generation to use the specified registry URL and derive the correct host for the auth token entry
- Pass `--registry` flag to `npm publish` command
- Show `--registry` flag in dry-run manual publish instructions and error recovery instructions
- Document `--registry` option in README

## Breaking Changes

None. The default registry value remains `https://registry.npmjs.org`, so existing usage is unaffected.

## Test Plan

- Run `setup-npm-trusted-publish my-package --dry-run` and verify the printed publish command includes `--registry https://registry.npmjs.org`
- Run with `--registry https://npm.pkg.github.com` and verify the `.npmrc` contains `registry=https://npm.pkg.github.com` and `//npm.pkg.github.com/:_authToken=${NPM_TOKEN}`
- Verify existing behavior without `--registry` flag is unchanged
