### PR TITLE
fix: handle already-published placeholder and use NPM_TOKEN for MFA

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -360,12 +360,21 @@ For more details about npm's trusted publishing feature, see:
       publishArgs.push('--userconfig', join(pkgDir, '.npmrc'));
     }
 
-    execFileSync('npm', publishArgs, {
-      cwd: pkgDir,
-      stdio: 'inherit'
-    });
-
-    console.log(`\n✅ Successfully published: ${pkgName}`);
+    try {
+      execFileSync('npm', publishArgs, {
+        cwd: pkgDir,
+        stdio: ['inherit', 'inherit', 'pipe']
+      });
+      console.log(`\n✅ Successfully published: ${pkgName}`);
+    } catch (publishError) {
+      const stderr = publishError.stderr?.toString() ?? '';
+      process.stderr.write(stderr);
+      if (stderr.includes('cannot publish over the previously published versions')) {
+        console.log(`\nℹ️  Package "${pkgName}" version 0.0.1 was previously published (and possibly unpublished). Skipping placeholder publish.`);
+        return;
+      }
+      throw publishError;
+    }
   } finally {
     if (!opts.dryRun) {
       try {
@@ -504,7 +513,29 @@ try {
 
 // Set MFA requirement if specified
 if (values.mfa && !values['dry-run']) {
-  setMfa(packageName, values);
+  // publishPlaceholder cleaned up its own .npmrc, so create a fresh one for npm access
+  const npmToken = process.env.NPM_TOKEN;
+  let mfaTempDir;
+  let mfaNpmrcPath;
+  if (npmToken) {
+    mfaTempDir = join(tmpdir(), `npm-mfa-${randomBytes(8).toString('hex')}`);
+    await mkdir(mfaTempDir, { recursive: true });
+    const registryUrl = new URL(values.registry);
+    mfaNpmrcPath = join(mfaTempDir, '.npmrc');
+    await writeFile(
+      mfaNpmrcPath,
+      `registry=${values.registry}\n//${registryUrl.host}/:_authToken=\${NPM_TOKEN}\n`
+    );
+  }
+  try {
+    setMfa(packageName, { ...values, npmrcPath: mfaNpmrcPath });
+  } finally {
+    if (mfaTempDir) {
+      try {
+        await rm(mfaTempDir, { recursive: true, force: true });
+      } catch {}
+    }
+  }
 }
 
 if (!values['dry-run']) {


### PR DESCRIPTION
## Summary

Fixes two reliability issues in `bin/cli.js`. The placeholder publish step now treats "cannot publish over the previously published versions" as a non-fatal condition, so users whose `0.0.1` was previously published (and possibly unpublished) can proceed to MFA/trust setup. The `--mfa` step now provisions its own temporary `.npmrc` with `NPM_TOKEN`, since `publishPlaceholder` cleans up its own config before `npm access set mfa` runs.

## Changes

- `publishPlaceholder`: capture stderr from `npm publish`, detect the "cannot publish over the previously published versions" message, log an informational message, and return without throwing. Other errors are still re-thrown.
- Top-level `--mfa` flow: when `NPM_TOKEN` is set, create a fresh temp directory with an `.npmrc` containing the registry and auth token, pass the path to `setMfa` via a new `npmrcPath` option, and clean up the temp directory in a `finally` block.

## Breaking Changes

None.

## Test Plan

- [ ] Run against a package whose `0.0.1` was previously published/unpublished and confirm the CLI continues past the publish step instead of erroring out.
- [ ] Run with `--mfa automation` and `NPM_TOKEN` set, and confirm `npm access set mfa` succeeds (no "need auth" failure) and the temp `.npmrc` is removed.
- [ ] Run normally for a brand-new package and confirm placeholder publish + MFA still works end-to-end.
- [ ] `node --experimental-strip-types ./test/test.ts` passes.
