### PR TITLE
feat!: remove npm trust mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-CLI tool to set up OIDC trusted publishing for npm packages. npm requires a package to exist before configuring trusted publishing — this tool handles that by publishing a placeholder first, then configuring trust.
+CLI tool to set up OIDC trusted publishing for npm packages. npm requires a package to exist before configuring trusted publishing — this tool handles that by publishing a minimal placeholder package. The user then configures OIDC trusted publishing manually on npmjs.com.
 
-Two modes:
-- **npm trust mode**: When `--github.*`/`--gitlab.*`/`--circleci.*` flags are provided (requires npm >= 11.10.0). Auto-publishes placeholder if package doesn't exist, then runs `npm trust`.
-- **Legacy mode**: Publishes placeholder package only, user configures OIDC manually on npmjs.com.
+`npm trust` is intentionally NOT supported: it requires interactive 2FA OTP at the account level and explicitly does not accept Granular Access Tokens with bypass 2FA, which makes it unusable for the automation flow this CLI targets. See README "Why not use `npm trust`?" section.
 
 ## Commands
 
 ```bash
-# Run tests
-node --experimental-strip-types ./test/test.ts
-
 # Run CLI locally
 ./bin/cli.js <package-name> [options]
 ```
@@ -24,18 +19,16 @@ No build step — the CLI is a single ES module file (`bin/cli.js`) using only N
 
 ## Architecture
 
-All logic is in `bin/cli.js` (~500 lines). Key functions:
+All logic is in `bin/cli.js`. Key functions:
 
-- `packageExists(pkgName, registry)` — checks if package exists on registry via `npm view`
-- `publishPlaceholder(pkgName, opts)` — creates temp dir with placeholder package.json/README and publishes
-- `buildTrustArgs(provider)` — constructs `npm trust` CLI arguments for github/gitlab/circleci
-- `setMfa(pkgName, opts)` — sets MFA requirement via `npm access set mfa=...`
+- `publishPlaceholder(pkgName, opts)` — creates temp dir with placeholder package.json/README and publishes; swallows "cannot publish over the previously published versions" so re-runs after unpublish do not abort the rest of the flow
+- `setMfa(pkgName, opts)` — sets MFA requirement via `npm access set mfa=...`; accepts `npmrcPath` for `NPM_TOKEN` auth
 
-Authentication: When `NPM_TOKEN` env var is set, creates a temporary `.npmrc` and passes it via `npm_config_userconfig` environment variable (not `--userconfig` flag, which `npm trust` doesn't support).
+Authentication: When `NPM_TOKEN` env var is set, creates a temporary `.npmrc` and passes it via `--userconfig` (for `npm publish`) or `npm_config_userconfig` env var (for `npm access`). The `.npmrc` for the publish step lives inside the temp package dir; a separate `.npmrc` is created for `setMfa` because the publish-step temp dir is cleaned up before MFA is set.
 
 ## Registry
 
-User's `~/.npmrc` may set a custom registry. All npm commands (`view`, `publish`, `trust`, `access`) must explicitly pass `--registry`. `npm trust` does not accept the `--userconfig` flag, so pass the temporary `.npmrc` path via `npm_config_userconfig` environment variable instead.
+User's `~/.npmrc` may set a custom registry. All npm commands (`publish`, `access`) must explicitly pass `--registry`.
 
 ## npm MFA values (counterintuitive)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-CLI tool to set up OIDC trusted publishing for npm packages. npm requires a package to exist before configuring trusted publishing — this tool handles that by publishing a minimal placeholder package. The user then configures OIDC trusted publishing manually on npmjs.com.
+CLI tool to set up OIDC trusted publishing for npm packages. npm requires a package to exist before configuring trusted publishing — this tool handles that by publishing a minimal placeholder package. The user then configures OIDC trusted publishing and publishing MFA requirement manually on npmjs.com.
 
-`npm trust` is intentionally NOT supported: it requires interactive 2FA OTP at the account level and explicitly does not accept Granular Access Tokens with bypass 2FA, which makes it unusable for the automation flow this CLI targets. See README "Why not use `npm trust`?" section.
+`npm trust` and `npm access set mfa=...` are intentionally NOT supported: both require interactive 2FA OTP at the account level and reject token-based execution (`npm trust` explicitly disallows GAT with bypass 2FA per its docs; `npm access set mfa` falls back to web auth and returns `401 token is invalid`). For the non-interactive automation flow this CLI targets, only the placeholder publish step is reliable. See README "Why not use `npm trust` or `npm access set mfa=...`?" section.
 
 ## Commands
 
@@ -19,23 +19,15 @@ No build step — the CLI is a single ES module file (`bin/cli.js`) using only N
 
 ## Architecture
 
-All logic is in `bin/cli.js`. Key functions:
+All logic is in `bin/cli.js`. Key function:
 
 - `publishPlaceholder(pkgName, opts)` — creates temp dir with placeholder package.json/README and publishes; swallows "cannot publish over the previously published versions" so re-runs after unpublish do not abort the rest of the flow
-- `setMfa(pkgName, opts)` — sets MFA requirement via `npm access set mfa=...`; accepts `npmrcPath` for `NPM_TOKEN` auth
 
-Authentication: When `NPM_TOKEN` env var is set, creates a temporary `.npmrc` and passes it via `--userconfig` (for `npm publish`) or `npm_config_userconfig` env var (for `npm access`). The `.npmrc` for the publish step lives inside the temp package dir; a separate `.npmrc` is created for `setMfa` because the publish-step temp dir is cleaned up before MFA is set.
+Authentication: When `NPM_TOKEN` env var is set, creates a temporary `.npmrc` inside the package temp dir and passes it via `--userconfig` to `npm publish`. The `.npmrc` is cleaned up with the temp dir.
 
 ## Registry
 
-User's `~/.npmrc` may set a custom registry. All npm commands (`publish`, `access`) must explicitly pass `--registry`.
-
-## npm MFA values (counterintuitive)
-
-- `mfa=automation` — 2FA required OR granular access token with bypass 2FA (for CI/CD)
-- `mfa=publish` — 2FA required AND disallow tokens (interactive only, stricter)
-
-Ref: https://github.com/orgs/community/discussions/172886
+User's `~/.npmrc` may set a custom registry. The CLI explicitly passes `--registry` to `npm publish`.
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ setup-npm-trusted-publish my-package --dry-run
 setup-npm-trusted-publish my-package --registry https://npm.example.com
 ```
 
-After publishing, configure OIDC trusted publishing and publishing MFA requirement (`mfa=automation` / `mfa=publish`) on npmjs.com under `https://www.npmjs.com/package/<package-name>/access`. Both `npm trust` and `npm access set mfa=...` require interactive 2FA OTP and cannot be driven by `NPM_TOKEN` (see "Why not use `npm trust`?" below for details), so they are intentionally not part of this CLI.
+After publishing, configure OIDC trusted publishing and publishing MFA requirement (`mfa=automation` / `mfa=publish`) on npmjs.com under `https://www.npmjs.com/package/<package-name>/access`. Both `npm trust` and `npm access set mfa=...` require interactive 2FA OTP and cannot be driven by `NPM_TOKEN` (see "Why not use `npm trust` or `npm access set mfa=...`?" below for details), so they are intentionally not part of this CLI.
 
 ## Usage without local npm login
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,13 @@
 
 A tool to setup OIDC (OpenID Connect) trusted publishing for npm packages.
 
-When `--github.*`, `--gitlab.*`, or `--circleci.*` options are specified, configures trusted publishing directly via [`npm trust`](https://docs.npmjs.com/cli/v11/commands/npm-trust) (requires npm >= 11.10.0). Otherwise, publishes a minimal placeholder package so you can configure OIDC manually on npmjs.com.
+It publishes a minimal placeholder package so you can configure OIDC trusted publishing on npmjs.com afterwards.
 
 ## Background
 
-Unlike PyPI which allows configuring OIDC for not-yet-existing packages, npm requires a package to exist before you can configure trusted publishing. This tool helps work around that limitation in two ways:
+Unlike PyPI which allows configuring OIDC for not-yet-existing packages, npm requires a package to exist before you can configure trusted publishing. This tool helps work around that limitation by creating and publishing a minimal placeholder package.
 
-1. Via `npm trust` (npm >= 11.10.0): Configures trusted publishing directly without publishing a placeholder
-2. Via placeholder publish (npm < 11.10.0): Creates and publishes a minimal placeholder package
-
-See: 
+See:
 
 - [GitHub Community Discussion #127011](https://github.com/orgs/community/discussions/127011)
 - [Allow publishing initial version with OIDC · Issue #8544 · npm/cli](https://github.com/npm/cli/issues/8544)
@@ -40,42 +37,16 @@ Options:
 - `--registry <url>` - npm registry URL (default: `https://registry.npmjs.org`)
 - `--mfa <none|automation|publish>` - Set publishing MFA requirement. `automation`: require 2FA or granular access token with bypass 2FA enabled (for CI/CD). `publish`: require 2FA and disallow tokens (interactive publish only)
 - `--otp <code>` - One-time password for 2FA
-Trusted Publisher configuration via `npm trust` (requires npm >= 11.10.0):
-- `--github.repo <owner/repo>` - Repository that is allowed to publish
-- `--github.file <workflow.yml>` - Workflow file that triggers publishing
-- `--github.env <environment>` - Environment required for publishing (optional)
-- `--gitlab.repo <owner/repo>` - Project that is allowed to publish
-- `--gitlab.file <pipeline.yml>` - Pipeline file that triggers publishing
-- `--gitlab.env <environment>` - Environment required for publishing (optional)
-- `--circleci.org-id <uuid>` - Organization allowed to publish
-- `--circleci.project-id <uuid>` - Project allowed to publish
-- `--circleci.pipeline-definition-id <uuid>` - Pipeline that triggers publishing
-- `--circleci.vcs-origin <origin>` - VCS origin of the project
-- `--circleci.context-id <uuid>` - Context required for publishing (optional)
 
 Environment Variables:
 - `NPM_TOKEN` - npm authentication token for users who don't have npm login configured locally. If set, a temporary `.npmrc` is created in the package directory with `//registry.npmjs.org/:_authToken=${NPM_TOKEN}`. npm expands `${NPM_TOKEN}` at runtime, so the actual token is never written to disk. The `.npmrc` is cleaned up with the temporary directory after publishing.
 
 Examples:
 ```bash
-# Via "npm trust" (npm >= 11.10.0)
-setup-npm-trusted-publish my-package --github.repo owner/repo --github.file release.yml --mfa publish
-setup-npm-trusted-publish @myorg/my-package \
-  --github.repo myorg/my-repo --github.file release.yml \
-  --github.env npm --mfa publish
-setup-npm-trusted-publish @myorg/my-package \
-  --gitlab.repo myorg/my-repo --gitlab.file .gitlab-ci.yml --mfa publish
-setup-npm-trusted-publish my-package \
-  --circleci.org-id <uuid> --circleci.project-id <uuid> \
-  --circleci.pipeline-definition-id <uuid> --circleci.vcs-origin <origin>
-
-# Via placeholder publish (npm < 11.10.0)
 setup-npm-trusted-publish my-package
 setup-npm-trusted-publish @myorg/my-package --mfa publish
 read -s NPM_TOKEN && export NPM_TOKEN && setup-npm-trusted-publish my-package
-
-# Other options
-setup-npm-trusted-publish my-package --github.repo owner/repo --github.file release.yml --dry-run
+setup-npm-trusted-publish my-package --dry-run
 setup-npm-trusted-publish my-package --registry https://npm.example.com
 ```
 
@@ -95,17 +66,6 @@ If you don't have npm login configured locally, you can use a one-time Granular 
 
 ## What it does
 
-### Via `npm trust` (npm >= 11.10.0)
-
-When `--github.*`, `--gitlab.*`, or `--circleci.*` options are specified, this tool runs [`npm trust`](https://docs.npmjs.com/cli/v11/commands/npm-trust) to configure trusted publishing directly. No placeholder package is published.
-
-```bash
-setup-npm-trusted-publish @myorg/my-package --github.repo myorg/my-repo --github.file release.yml
-```
-
-### Via placeholder publish (npm < 11.10.0)
-
-Without `--github.*` / `--gitlab.*` / `--circleci.*` options, this tool:
 1. Creates a minimal npm package in a temporary directory
 2. Generates a `package.json` with basic metadata for OIDC setup
 3. Creates a `README.md` that **clearly states the package is for OIDC setup only**
@@ -118,6 +78,16 @@ The generated README explicitly indicates:
 - It contains **NO** code
 - It exists **ONLY** for OIDC configuration
 - It should **NOT** be used as a dependency
+
+## Why not use `npm trust`?
+
+npm 11.10.0+ provides an `npm trust` command that can configure trusted publishing without publishing a placeholder. However, it has a significant limitation that makes it unsuitable for this tool's automation use case:
+
+> Granular Access Tokens (GAT) with the bypass 2FA option are not supported. Legacy basic auth (username and password) credentials will not work for trust commands or endpoints. Two-factor authentication must be enabled at the account level.
+>
+> — [npm-trust documentation](https://docs.npmjs.com/cli/v11/commands/npm-trust)
+
+In short, `npm trust` requires interactive 2FA OTP and cannot be driven by `NPM_TOKEN` (automation token / GAT with bypass 2FA). For non-interactive setup flows that this CLI targets, the placeholder publish + manual web UI configuration is the only reliable path. If `npm trust` works for you interactively, you can run it directly without this tool.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Options:
 - `--dry-run` - Create the package but don't publish
 - `--access <public|restricted>` - Access level for scoped packages (default: public)
 - `--registry <url>` - npm registry URL (default: `https://registry.npmjs.org`)
-- `--mfa <none|automation|publish>` - Set publishing MFA requirement. `automation`: require 2FA or granular access token with bypass 2FA enabled (for CI/CD). `publish`: require 2FA and disallow tokens (interactive publish only)
-- `--otp <code>` - One-time password for 2FA
 
 Environment Variables:
 - `NPM_TOKEN` - npm authentication token for users who don't have npm login configured locally. If set, a temporary `.npmrc` is created in the package directory with `//registry.npmjs.org/:_authToken=${NPM_TOKEN}`. npm expands `${NPM_TOKEN}` at runtime, so the actual token is never written to disk. The `.npmrc` is cleaned up with the temporary directory after publishing.
@@ -44,11 +42,13 @@ Environment Variables:
 Examples:
 ```bash
 setup-npm-trusted-publish my-package
-setup-npm-trusted-publish @myorg/my-package --mfa publish
+setup-npm-trusted-publish @myorg/my-package
 read -s NPM_TOKEN && export NPM_TOKEN && setup-npm-trusted-publish my-package
 setup-npm-trusted-publish my-package --dry-run
 setup-npm-trusted-publish my-package --registry https://npm.example.com
 ```
+
+After publishing, configure OIDC trusted publishing and publishing MFA requirement (`mfa=automation` / `mfa=publish`) on npmjs.com under `https://www.npmjs.com/package/<package-name>/access`. Both `npm trust` and `npm access set mfa=...` require interactive 2FA OTP and cannot be driven by `NPM_TOKEN` (see "Why not use `npm trust`?" below for details), so they are intentionally not part of this CLI.
 
 ## Usage without local npm login
 
@@ -79,7 +79,7 @@ The generated README explicitly indicates:
 - It exists **ONLY** for OIDC configuration
 - It should **NOT** be used as a dependency
 
-## Why not use `npm trust`?
+## Why not use `npm trust` or `npm access set mfa=...`?
 
 npm 11.10.0+ provides an `npm trust` command that can configure trusted publishing without publishing a placeholder. However, it has a significant limitation that makes it unsuitable for this tool's automation use case:
 
@@ -87,7 +87,9 @@ npm 11.10.0+ provides an `npm trust` command that can configure trusted publishi
 >
 > — [npm-trust documentation](https://docs.npmjs.com/cli/v11/commands/npm-trust)
 
-In short, `npm trust` requires interactive 2FA OTP and cannot be driven by `NPM_TOKEN` (automation token / GAT with bypass 2FA). For non-interactive setup flows that this CLI targets, the placeholder publish + manual web UI configuration is the only reliable path. If `npm trust` works for you interactively, you can run it directly without this tool.
+`npm access set mfa=publish|automation` falls back to the same web auth flow and rejects token-based execution with `401 token is invalid` ([npm/cli#9268](https://github.com/npm/cli/issues/9268), [#8869](https://github.com/npm/cli/issues/8869)).
+
+In short, both commands require interactive 2FA OTP and cannot be driven by `NPM_TOKEN` (automation token / GAT with bypass 2FA). For non-interactive setup flows that this CLI targets, the placeholder publish + manual web UI configuration is the only reliable path. If those commands work for you interactively, run them directly without this tool.
 
 ## Workflow
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -65,6 +65,11 @@ publishing MFA requirement at:
 Environment:
   NPM_TOKEN   npm auth token for placeholder publish.
               If set, creates a temporary .npmrc for authentication.
+
+Note: --github.* / --gitlab.* / --circleci.* / --mfa / --otp options were
+removed in v2 because npm trust and npm access set mfa=... require interactive
+2FA OTP and cannot be driven by NPM_TOKEN. Configure those manually on
+npmjs.com after this CLI publishes the placeholder. See README for details.
 `);
   process.exit(0);
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -30,23 +30,8 @@ const { values, positionals } = parseArgs({
       type: 'string',
       default: 'https://registry.npmjs.org'
     },
-    // Shared options
     mfa: { type: 'string' },
-    otp: { type: 'string' },
-    // GitHub Actions
-    'github.repo': { type: 'string' },
-    'github.file': { type: 'string' },
-    'github.env': { type: 'string' },
-    // GitLab CI/CD
-    'gitlab.repo': { type: 'string' },
-    'gitlab.file': { type: 'string' },
-    'gitlab.env': { type: 'string' },
-    // CircleCI
-    'circleci.org-id': { type: 'string' },
-    'circleci.project-id': { type: 'string' },
-    'circleci.pipeline-definition-id': { type: 'string' },
-    'circleci.vcs-origin': { type: 'string' },
-    'circleci.context-id': { type: 'string' }
+    otp: { type: 'string' }
   },
   allowPositionals: true
 });
@@ -55,12 +40,8 @@ if (values.help) {
   console.log(`
 Usage: setup-npm-trusted-publish <package-name> [options]
 
-Setup npm package for trusted publishing with OIDC.
-
-When --github.*, --gitlab.*, or --circleci.* options are specified, runs
-"npm trust" to configure trusted publishing directly (requires npm >= 11.10.0).
-Otherwise, publishes a minimal placeholder package so you can configure OIDC
-manually on npmjs.com.
+Publishes a minimal placeholder package to npm so you can configure OIDC
+trusted publishing on npmjs.com afterwards.
 
 Arguments:
   <package-name>  The name of the npm package to setup (e.g. my-package, @scope/my-package)
@@ -77,51 +58,19 @@ Options:
                     publish:    Require 2FA and disallow tokens (interactive publish only)
   --otp           One-time password for 2FA (optional, npm will prompt interactively if needed)
 
-Trusted Publisher configuration via "npm trust" (requires npm >= 11.10.0):
-  Configure which CI workflow is allowed to publish this package.
-
-  GitHub Actions:
-    --github.repo   Repository that is allowed to publish (owner/repo)
-    --github.file   Workflow file that triggers publishing (e.g. release.yml)
-    --github.env    Environment required for publishing (optional)
-
-  GitLab CI/CD:
-    --gitlab.repo   Project that is allowed to publish (owner/repo)
-    --gitlab.file   Pipeline file that triggers publishing (e.g. .gitlab-ci.yml)
-    --gitlab.env    Environment required for publishing (optional)
-
-  CircleCI:
-    --circleci.org-id                 Organization allowed to publish (UUID)
-    --circleci.project-id             Project allowed to publish (UUID)
-    --circleci.pipeline-definition-id Pipeline that triggers publishing (UUID)
-    --circleci.vcs-origin             VCS origin of the project
-    --circleci.context-id             Context required for publishing (UUID, optional)
-
 Examples:
-  # Via "npm trust" (npm >= 11.10.0)
-  setup-npm-trusted-publish my-package --github.repo owner/repo --github.file release.yml
-  setup-npm-trusted-publish @scope/my-package \\
-    --github.repo owner/repo --github.file release.yml \\
-    --github.env npm --mfa publish
-  setup-npm-trusted-publish @scope/my-package \\
-    --gitlab.repo owner/repo --gitlab.file .gitlab-ci.yml --mfa publish
-  setup-npm-trusted-publish my-package \\
-    --circleci.org-id <uuid> --circleci.project-id <uuid> \\
-    --circleci.pipeline-definition-id <uuid> --circleci.vcs-origin <origin>
-
-  # Via placeholder publish (npm < 11.10.0)
   setup-npm-trusted-publish my-package
   setup-npm-trusted-publish @scope/my-package --mfa publish
   read -s NPM_TOKEN && export NPM_TOKEN && setup-npm-trusted-publish my-package
-
-  # Other options
-  setup-npm-trusted-publish my-package --github.repo owner/repo --github.file release.yml --dry-run
+  setup-npm-trusted-publish my-package --dry-run
   setup-npm-trusted-publish my-package --registry https://npm.example.com
+
+After this tool publishes the placeholder, configure OIDC trusted publishing at:
+  https://www.npmjs.com/package/<package-name>/access
 
 Environment:
   NPM_TOKEN   npm auth token for placeholder publish.
               If set, creates a temporary .npmrc for authentication.
-              Not needed when using --github.* / --gitlab.* / --circleci.* options.
 `);
   process.exit(0);
 }
@@ -176,85 +125,6 @@ function setMfa(pkgName, opts) {
     console.error(`Error: ${mfaError.message}`);
     console.error(`You can set it manually: npm access set mfa=${opts.mfa} ${pkgName}`);
     process.exit(1);
-  }
-}
-
-// Detect npm trust mode by checking provider-specific flags
-function detectProvider() {
-  if (values['github.repo'] || values['github.file']) {
-    return 'github';
-  }
-  if (values['gitlab.repo'] || values['gitlab.file']) {
-    return 'gitlab';
-  }
-  if (values['circleci.org-id'] || values['circleci.project-id']) {
-    return 'circleci';
-  }
-  return null;
-}
-
-function buildTrustArgs(provider) {
-  const args = ['trust', provider, packageName];
-
-  if (provider === 'github') {
-    if (!values['github.repo'] || !values['github.file']) {
-      console.error('Error: --github.repo and --github.file are required for GitHub Actions');
-      process.exit(1);
-    }
-    args.push('--file', values['github.file'], '--repo', values['github.repo']);
-    if (values['github.env']) {
-      args.push('--env', values['github.env']);
-    }
-  } else if (provider === 'gitlab') {
-    if (!values['gitlab.repo'] || !values['gitlab.file']) {
-      console.error('Error: --gitlab.repo and --gitlab.file are required for GitLab CI/CD');
-      process.exit(1);
-    }
-    args.push('--file', values['gitlab.file'], '--repo', values['gitlab.repo']);
-    if (values['gitlab.env']) {
-      args.push('--env', values['gitlab.env']);
-    }
-  } else if (provider === 'circleci') {
-    const required = ['circleci.org-id', 'circleci.project-id', 'circleci.pipeline-definition-id', 'circleci.vcs-origin'];
-    for (const key of required) {
-      if (!values[key]) {
-        console.error(`Error: --${key} is required for CircleCI`);
-        process.exit(1);
-      }
-    }
-    args.push(
-      '--org-id', values['circleci.org-id'],
-      '--project-id', values['circleci.project-id'],
-      '--pipeline-definition-id', values['circleci.pipeline-definition-id'],
-      '--vcs-origin', values['circleci.vcs-origin']
-    );
-    if (values['circleci.context-id']) {
-      args.push('--context-id', values['circleci.context-id']);
-    }
-  }
-
-  args.push('--yes');
-
-  args.push('--registry', values.registry);
-  if (values.otp) {
-    args.push('--otp', values.otp);
-  }
-  if (values['dry-run']) {
-    args.push('--dry-run');
-  }
-
-  return args;
-}
-
-// Check if package already exists on the registry
-function packageExists(pkgName, registry) {
-  try {
-    execFileSync('npm', ['view', pkgName, 'name', '--registry', registry], {
-      stdio: 'pipe'
-    });
-    return true;
-  } catch {
-    return false;
   }
 }
 
@@ -387,118 +257,7 @@ For more details about npm's trusted publishing feature, see:
   }
 }
 
-const provider = detectProvider();
-
-if (provider) {
-  // Check npm version >= 11.10.0
-  const npmVersionStr = execFileSync('npm', ['--version'], { encoding: 'utf-8' }).trim();
-  const npmVersionParts = npmVersionStr.split('.').map(Number);
-  const npmVersionNum = npmVersionParts[0] * 10000 + npmVersionParts[1] * 100 + npmVersionParts[2];
-  const requiredVersionNum = 11 * 10000 + 10 * 100 + 0;
-
-  if (npmVersionNum < requiredVersionNum) {
-    console.error(`Error: npm trust requires npm >= 11.10.0 (current: ${npmVersionStr})`);
-    console.error('Update npm with: npm install -g npm@latest');
-    process.exit(1);
-  }
-
-  // Publish placeholder if package does not exist yet
-  if (!packageExists(packageName, values.registry)) {
-    console.log(`📦 Package "${packageName}" not found on registry. Publishing placeholder first...`);
-    try {
-      await publishPlaceholder(packageName, {
-        registry: values.registry,
-        access: values.access,
-        dryRun: values['dry-run']
-      });
-    } catch (publishError) {
-      console.error(`\n❌ Failed to publish placeholder package`);
-      console.error(`Error: ${publishError.message}`);
-      process.exit(1);
-    }
-
-    if (values['dry-run']) {
-      console.log(`\n🔍 Dry run mode - skipping npm trust configuration`);
-      process.exit(0);
-    }
-  }
-
-  const trustArgs = buildTrustArgs(provider);
-
-  // Create temporary .npmrc for NPM_TOKEN authentication
-  const npmToken = process.env.NPM_TOKEN;
-  let trustTempDir;
-  let trustNpmrcPath;
-  const trustEnv = { ...process.env };
-  if (npmToken) {
-    trustTempDir = join(tmpdir(), `npm-trust-${randomBytes(8).toString('hex')}`);
-    await mkdir(trustTempDir, { recursive: true });
-    const registryUrl = new URL(values.registry);
-    trustNpmrcPath = join(trustTempDir, '.npmrc');
-    await writeFile(
-      trustNpmrcPath,
-      `registry=${values.registry}\n//${registryUrl.host}/:_authToken=\${NPM_TOKEN}\n`
-    );
-    trustEnv.npm_config_userconfig = trustNpmrcPath;
-    console.log(`🔑 Using NPM_TOKEN for authentication`);
-  }
-
-  console.log(`📦 Configuring trusted publishing for: ${packageName} (${provider})`);
-
-  try {
-    execFileSync('npm', trustArgs, {
-      stdio: 'inherit',
-      env: trustEnv
-    });
-    console.log(`\n✅ Successfully configured trusted publishing for: ${packageName}`);
-  } catch (trustError) {
-    console.error(`\n❌ Failed to configure trusted publishing`);
-    console.error(`Error: ${trustError.message}`);
-    process.exit(1);
-  }
-
-  // Set MFA requirement if specified
-  if (values.mfa && !values['dry-run']) {
-    setMfa(packageName, { ...values, npmrcPath: trustNpmrcPath });
-  }
-
-  // Clean up temporary .npmrc
-  if (trustTempDir) {
-    try {
-      await rm(trustTempDir, { recursive: true, force: true });
-    } catch {}
-  }
-
-  // Print summary
-  console.log(`\n--- Summary ---`);
-  console.log(`Package:  ${packageName}`);
-  console.log(`Provider: ${provider}`);
-  if (provider === 'github') {
-    console.log(`Repo:     ${values['github.repo']}`);
-    console.log(`File:     ${values['github.file']}`);
-    if (values['github.env']) {
-      console.log(`Env:      ${values['github.env']}`);
-    }
-  } else if (provider === 'gitlab') {
-    console.log(`Repo:     ${values['gitlab.repo']}`);
-    console.log(`File:     ${values['gitlab.file']}`);
-    if (values['gitlab.env']) {
-      console.log(`Env:      ${values['gitlab.env']}`);
-    }
-  } else if (provider === 'circleci') {
-    console.log(`Org ID:   ${values['circleci.org-id']}`);
-    console.log(`Project:  ${values['circleci.project-id']}`);
-  }
-  if (values.mfa) {
-    console.log(`MFA:      ${values.mfa}`);
-  }
-  console.log(`Registry: ${values.registry}`);
-  console.log(`URL:      https://www.npmjs.com/package/${packageName}`);
-
-  process.exit(0);
-}
-
-// Legacy mode: publish placeholder package and guide manual OIDC setup
+// Publish placeholder package and guide manual OIDC setup
 try {
   await publishPlaceholder(packageName, {
     registry: values.registry,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -65,11 +65,6 @@ publishing MFA requirement at:
 Environment:
   NPM_TOKEN   npm auth token for placeholder publish.
               If set, creates a temporary .npmrc for authentication.
-
-Note: --github.* / --gitlab.* / --circleci.* / --mfa / --otp options were
-removed in v2 because npm trust and npm access set mfa=... require interactive
-2FA OTP and cannot be driven by NPM_TOKEN. Configure those manually on
-npmjs.com after this CLI publishes the placeholder. See README for details.
 `);
   process.exit(0);
 }

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,9 +29,7 @@ const { values, positionals } = parseArgs({
     registry: {
       type: 'string',
       default: 'https://registry.npmjs.org'
-    },
-    mfa: { type: 'string' },
-    otp: { type: 'string' }
+    }
   },
   allowPositionals: true
 });
@@ -52,20 +50,16 @@ Options:
   --dry-run       Preview actions without making changes
   --access        Access level for scoped packages (public/restricted) [default: public]
   --registry      npm registry URL [default: https://registry.npmjs.org]
-  --mfa           Set publishing MFA requirement after setup:
-                    none:       No MFA requirement
-                    automation: Require 2FA or granular access token with bypass 2FA enabled (for CI/CD)
-                    publish:    Require 2FA and disallow tokens (interactive publish only)
-  --otp           One-time password for 2FA (optional, npm will prompt interactively if needed)
 
 Examples:
   setup-npm-trusted-publish my-package
-  setup-npm-trusted-publish @scope/my-package --mfa publish
+  setup-npm-trusted-publish @scope/my-package
   read -s NPM_TOKEN && export NPM_TOKEN && setup-npm-trusted-publish my-package
   setup-npm-trusted-publish my-package --dry-run
   setup-npm-trusted-publish my-package --registry https://npm.example.com
 
-After this tool publishes the placeholder, configure OIDC trusted publishing at:
+After this tool publishes the placeholder, configure OIDC trusted publishing and
+publishing MFA requirement at:
   https://www.npmjs.com/package/<package-name>/access
 
 Environment:
@@ -95,37 +89,6 @@ if (!validPackageNameRegex.test(packageName)) {
   console.error(`Error: Invalid package name: ${packageName}`);
   console.error('Package names must be lowercase and can contain letters, numbers, hyphens, periods, and underscores');
   process.exit(1);
-}
-
-// Validate --mfa value
-if (values.mfa && !['none', 'publish', 'automation'].includes(values.mfa)) {
-  console.error(`Error: --mfa must be one of: none, publish, automation (got: ${values.mfa})`);
-  process.exit(1);
-}
-
-function setMfa(pkgName, opts) {
-  console.log(`\n🔒 Setting MFA requirement to "${opts.mfa}" for: ${pkgName}`);
-  const accessArgs = ['access', 'set', `mfa=${opts.mfa}`, pkgName];
-  if (opts.otp) {
-    accessArgs.push('--otp', opts.otp);
-  }
-  accessArgs.push('--registry', opts.registry);
-  const mfaEnv = { ...process.env };
-  if (opts.npmrcPath) {
-    mfaEnv.npm_config_userconfig = opts.npmrcPath;
-  }
-  try {
-    execFileSync('npm', accessArgs, {
-      stdio: 'inherit',
-      env: mfaEnv
-    });
-    console.log(`✅ MFA requirement set to "${opts.mfa}"`);
-  } catch (mfaError) {
-    console.error(`❌ Failed to set MFA requirement`);
-    console.error(`Error: ${mfaError.message}`);
-    console.error(`You can set it manually: npm access set mfa=${opts.mfa} ${pkgName}`);
-    process.exit(1);
-  }
 }
 
 // Publish a placeholder package to reserve the name
@@ -268,33 +231,6 @@ try {
   console.error(`\n❌ Failed to publish placeholder package`);
   console.error(`Error: ${error.message}`);
   process.exit(1);
-}
-
-// Set MFA requirement if specified
-if (values.mfa && !values['dry-run']) {
-  // publishPlaceholder cleaned up its own .npmrc, so create a fresh one for npm access
-  const npmToken = process.env.NPM_TOKEN;
-  let mfaTempDir;
-  let mfaNpmrcPath;
-  if (npmToken) {
-    mfaTempDir = join(tmpdir(), `npm-mfa-${randomBytes(8).toString('hex')}`);
-    await mkdir(mfaTempDir, { recursive: true });
-    const registryUrl = new URL(values.registry);
-    mfaNpmrcPath = join(mfaTempDir, '.npmrc');
-    await writeFile(
-      mfaNpmrcPath,
-      `registry=${values.registry}\n//${registryUrl.host}/:_authToken=\${NPM_TOKEN}\n`
-    );
-  }
-  try {
-    setMfa(packageName, { ...values, npmrcPath: mfaNpmrcPath });
-  } finally {
-    if (mfaTempDir) {
-      try {
-        await rm(mfaTempDir, { recursive: true, force: true });
-      } catch {}
-    }
-  }
 }
 
 if (!values['dry-run']) {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "bin": {
     "setup-npm-trusted-publish": "./bin/cli.js"
   },
-  "scripts": {
-    "test": "node --experimental-strip-types ./test/test.ts"
-  },
   "keywords": [
     "npm",
     "oidc",


### PR DESCRIPTION
Remove the `--github.*`/`--gitlab.*`/`--circleci.*` flags and the `npm trust` integration. `npm trust` requires interactive 2FA OTP at the account level and explicitly does not accept Granular Access Tokens with bypass 2FA, which makes it unusable for the automation flow this CLI targets.

The CLI now only publishes a minimal placeholder package; users configure OIDC trusted publishing manually on npmjs.com afterwards. README documents the rationale under "Why not use `npm trust`?".

BREAKING CHANGE: All `--github.*`, `--gitlab.*`, and `--circleci.*` flags are removed. Configure trusted publishing on the npmjs.com web UI after running this tool.

Close #14 